### PR TITLE
Remove snow effect and add rooftop beacons

### DIFF
--- a/cityLights.js
+++ b/cityLights.js
@@ -1,5 +1,6 @@
 const CityLights = (() => {
   const lights = [];
+  const beacons = [];
   const canvas = document.createElement('canvas');
   canvas.width = canvas.height = 32;
   const ctx = canvas.getContext('2d');
@@ -19,13 +20,27 @@ const CityLights = (() => {
     return sprite;
   }
 
+  function createBeacon() {
+    const material = baseMaterial.clone();
+    material.color.set(0xff0000);
+    const sprite = new THREE.Sprite(material);
+    sprite.scale.set(0.5, 0.5, 1);
+    sprite.userData.phase = Math.random() * Math.PI * 2;
+    beacons.push(sprite);
+    return sprite;
+  }
+
   function update(time) {
     const t = time * 0.002;
     for (let i = 0; i < lights.length; i++) {
       const l = lights[i];
       l.material.opacity = 0.3 + 0.2 * Math.sin(t + l.position.x);
     }
+    for (let i = 0; i < beacons.length; i++) {
+      const b = beacons[i];
+      b.material.opacity = Math.sin(time * 0.01 + b.userData.phase) > 0 ? 1 : 0.1;
+    }
   }
 
-  return { createLight, update };
+  return { createLight, createBeacon, update };
 })();

--- a/index.html
+++ b/index.html
@@ -540,9 +540,8 @@ createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -200), -Math.PI/2, 0x00ff
 // Use a darker color for better contrast on the gantry billboard
 createGantryBillboard(-90, 0x003366, 'Introducing Mint Condition™');
 
-// Motion particles - use a single Points object to reduce draw calls
-// Reduced count and size to clean up snow-like effect
-const particleCount = 80;
+// Motion particles - disabled to fully remove snow-like effect
+const particleCount = 0;
 const particleGeometry = new THREE.BufferGeometry();
 const positions = new Float32Array(particleCount * 3);
 const speeds = new Float32Array(particleCount);
@@ -722,6 +721,12 @@ function createBuilding(x, z) {
                       height / 2 + roofHeight + 0.1,
                       (Math.random() - 0.5) * depth * 0.4);
     building.add(hvac);
+
+    // Small blinking red beacon on the roof
+    const beacon = CityLights.createBeacon();
+    beacon.position.set(0, height / 2 + roofHeight + 0.2, 0);
+    building.add(beacon);
+    building.userData.beacon = beacon;
 
     if (Math.random() > 0.7) {
         const towerGeo = new THREE.CylinderGeometry(width * 0.15, width * 0.15, 0.8, 12);


### PR DESCRIPTION
## Summary
- completely disable motion particles to get rid of remaining snow
- add blinking red beacons to rooftops
- extend CityLights helper with createBeacon and blink logic

## Testing
- `npm test`