### PR TITLE
Add image support for billboards

### DIFF
--- a/billboards/README.md
+++ b/billboards/README.md
@@ -1,1 +1,3 @@
-This folder stores billboard images for the game.
+This folder stores billboard images for the game. Images placed here can be used on in-game billboards.
+
+You can add your own advertisement files (PNG, JPG, or SVG) and reference them when creating billboards.

--- a/billboards/ad1.svg
+++ b/billboards/ad1.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="256" viewBox="0 0 512 256">
+  <rect width="512" height="256" fill="#1E90FF"/>
+  <text x="50%" y="50%" font-family="Arial" font-size="70" fill="white" dy="10" text-anchor="middle">COOL TECH</text>
+</svg>

--- a/billboards/ad2.svg
+++ b/billboards/ad2.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="256" viewBox="0 0 512 256">
+  <rect width="512" height="256" fill="#FF1493"/>
+  <text x="50%" y="50%" font-family="Arial" font-size="70" fill="yellow" dy="10" text-anchor="middle">NEON CITY</text>
+</svg>

--- a/billboards/ad3.svg
+++ b/billboards/ad3.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="256" viewBox="0 0 512 256">
+  <rect width="512" height="256" fill="black"/>
+  <circle cx="256" cy="128" r="80" fill="#FFD700"/>
+  <text x="256" y="140" font-family="Arial" font-size="60" fill="black" text-anchor="middle">GOLD</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -408,14 +408,20 @@ finishLine.visible = false;
 // Create simple billboards
 const billboards = [];
 
-function createBillboard(position, rotation = 0, color = 0x00ffff, adText = '') {
+function createBillboard(position, rotation = 0, color = 0x00ffff, adText = '', adImage = null) {
     // Enhanced billboard implementation with color options and tilt
     const width = 6;
     const height = 3;
     
-    // Create canvas texture for billboard if ad text is provided
+    // Create canvas texture or load image for the billboard
     let material;
-    if (adText) {
+    if (adImage) {
+        const texture = new THREE.TextureLoader().load(adImage);
+        material = new THREE.MeshBasicMaterial({
+            map: texture,
+            side: THREE.DoubleSide
+        });
+    } else if (adText) {
         const canvas = document.createElement('canvas');
         canvas.width = 512;
         canvas.height = 256;
@@ -475,7 +481,7 @@ function createBillboard(position, rotation = 0, color = 0x00ffff, adText = '') 
     return billboard;
 }
 
-function createGantryBillboard(z, color = 0xff6600, adText = '') {
+function createGantryBillboard(z, color = 0xff6600, adText = '', adImage = null) {
     const gantry = new THREE.Group();
 
     // Support posts on each side of the track
@@ -494,7 +500,10 @@ function createGantryBillboard(z, color = 0xff6600, adText = '') {
     const width = trackWidth + 2;
     const height = 2;
     let material;
-    if (adText) {
+    if (adImage) {
+        const texture = new THREE.TextureLoader().load(adImage);
+        material = new THREE.MeshBasicMaterial({ map: texture, side: THREE.DoubleSide });
+    } else if (adText) {
         const canvas = document.createElement('canvas');
         canvas.width = 512;
         canvas.height = 128;
@@ -525,7 +534,7 @@ function createGantryBillboard(z, color = 0xff6600, adText = '') {
 
 // Add billboards along the track with neon colors and F1-themed ads
 // Left side billboards
-createBillboard(new THREE.Vector3(-trackWidth/2 - 2, 3, -20), Math.PI/2, 0xff00ff, 'MIAMI');       // Magenta
+createBillboard(new THREE.Vector3(-trackWidth/2 - 2, 3, -20), Math.PI/2, 0xff00ff, '', 'billboards/ad1.svg');       // Magenta image
 createBillboard(new THREE.Vector3(-trackWidth/2 - 2, 3, -60), Math.PI/2, 0x00ffff, 'GRAND PRIX'); // Cyan
 createBillboard(new THREE.Vector3(-trackWidth/2 - 2, 3, -100), Math.PI/2, 0xffff00, 'SPEED');      // Yellow
 createBillboard(new THREE.Vector3(-trackWidth/2 - 2, 3, -140), Math.PI/2, 0xff00ff, 'RACING');     // Magenta
@@ -534,13 +543,13 @@ createBillboard(new THREE.Vector3(-trackWidth/2 - 2, 3, -180), Math.PI/2, 0x00ff
 // Right side billboards
 createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -40), -Math.PI/2, 0x00ffff, 'F1');         // Cyan
 createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -80), -Math.PI/2, 0xff00ff, 'NEON');       // Magenta
-createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -120), -Math.PI/2, 0x00ff00, 'RACER');      // Green
+createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -120), -Math.PI/2, 0x00ff00, '', 'billboards/ad2.svg');      // Green image
 createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -160), -Math.PI/2, 0xff00ff, 'FASTEST');    // Magenta
 createBillboard(new THREE.Vector3(trackWidth/2 + 2, 3, -200), -Math.PI/2, 0x00ffff, 'LAP');        // Cyan
 
 // Overhead gantry billboard spanning the track
 // Use a darker color for better contrast on the gantry billboard
-createGantryBillboard(-90, 0x003366, 'Introducing Mint Condition™');
+createGantryBillboard(-90, 0x003366, '', 'billboards/ad3.svg');
 
 
 // Barriers and obstacles


### PR DESCRIPTION
## Summary
- allow billboards to use texture images
- add optional image parameter to billboard creation functions
- demonstrate with new sample SVG ads
- document billboard images

## Testing
- `npm test`