### PR TITLE
Fix high score stored as number

### DIFF
--- a/game.js
+++ b/game.js
@@ -1,7 +1,7 @@
 import { inputManager } from './inputManager.js';
 
-// Load and store high score
-let highScore = localStorage.getItem('f1RacerHighScore') || 0;
+// Load and store high score as a numeric value
+let highScore = parseFloat(localStorage.getItem('f1RacerHighScore')) || 0;
 document.getElementById('highScore').textContent = 'High Score: ' + Math.floor(highScore);
 
 // Lap tracking


### PR DESCRIPTION
## Summary
- ensure high score value is parsed as numeric when loaded

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68423ae4a6f0832caf75f5cb7d978694