### PR TITLE
Prevent runaway speed after first lap

### DIFF
--- a/game.js
+++ b/game.js
@@ -1259,6 +1259,9 @@ function animate(time) {
             speed += baseSpeedIncrease;
         }
 
+        // Prevent runaway acceleration at higher laps
+        speed = Math.min(speed, maxSpeed);
+
         if (score > highScore) {
             highScore = score;
             document.getElementById('highScore').textContent = 'High Score: ' + Math.floor(highScore);


### PR DESCRIPTION
## Summary
- cap the per-frame speed so it never exceeds `maxSpeed`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684257e67df4832cbb5a02befd12e55d